### PR TITLE
Updated default healthcheck config and upgraded to latest dp-healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ returning children and parents (breadcrumbs) for the requested node.
 
 ### Configuration
 
-| Environment variable        | Default                                   | Description
-| --------------------------- | ----------------------------------------- | -----------
-| BIND_ADDR                   | :22600                                    | The host and port to bind to
-| HIERARCHY_API_URL           | http://localhost:22600                    | The external address of this API
-| GRACEFUL_SHUTDOWN_TIMEOUT   | 5s                                        | The graceful shutdown timeout (Go `time.Duration` format)
-| CODE_LIST_URL               | http://localhost:22400                    | The external address of the Code List API
+| Environment variable         | Default                                   | Description
+| ---------------------------- | ----------------------------------------- | -----------
+| BIND_ADDR                    | :22600                                    | The host and port to bind to
+| HIERARCHY_API_URL            | http://localhost:22600                    | The external address of this API
+| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                                        | The graceful shutdown timeout (Go `time.Duration` format)
+| CODE_LIST_URL                | http://localhost:22400                    | The external address of the Code List API
+| HEALTHCHECK_INTERVAL         | 30s                                       | The time between doing health checks
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                       | The time taken for the health changes from warning state to critical due to subsystem check failures
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ func Get() (*Config, error) {
 			HierarchyAPIURL:            "http://localhost:22600",
 			ShutdownTimeout:            5 * time.Second,
 			HealthCheckInterval:        30 * time.Second,
-			HealthCheckCriticalTimeout: 5 * time.Second,
+			HealthCheckCriticalTimeout: 90 * time.Second,
 			CodelistAPIURL:             "http://localhost:22400",
 		}
 		if err := envconfig.Process("", configuration); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -11,8 +12,13 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 	Convey("When a loading a configuration, default values are return", t, func() {
 		config, err := Get()
 		So(err, ShouldBeNil)
-		So(config.BindAddr, ShouldEqual, ":22600")
-		So(config.HierarchyAPIURL, ShouldEqual, "http://localhost:22600")
-		So(config.CodelistAPIURL, ShouldEqual, "http://localhost:22400")
+		So(config, ShouldResemble, &Config{
+			BindAddr:                   ":22600",
+			HierarchyAPIURL:            "http://localhost:22600",
+			CodelistAPIURL:             "http://localhost:22400",
+			ShutdownTimeout:            5 * time.Second,
+			HealthCheckInterval:        30 * time.Second,
+			HealthCheckCriticalTimeout: 90 * time.Second,
+		})
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.9.0
 	github.com/ONSdigital/dp-graph v1.0.2
-	github.com/ONSdigital/dp-healthcheck v1.0.2
+	github.com/ONSdigital/dp-healthcheck v1.0.3
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/gorilla/mux v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/ONSdigital/dp-graph v1.0.2/go.mod h1:QxXzx2k8rbE2asyp6uG4bwG5zo04nqQM
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
 github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
-github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=
-github.com/ONSdigital/dp-healthcheck v1.0.2/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
+github.com/ONSdigital/dp-healthcheck v1.0.3 h1:wNA34U3uPD5t1SE8P3cbGqNZP4CUjyJFbSugPYgrBG0=
+github.com/ONSdigital/dp-healthcheck v1.0.3/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-hierarchy-api v0.0.0-20190530123622-0be246287b59/go.mod h1:1oE930hQ6vS/5KFL2aXBlHb1nPF78ZsFkE2eQ4CvrZg=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-observation-importer v0.0.0-20190530123707-54356cab6a79 h1:pc396Dg9lbMYa7zQaOse5QCRahW2XWO3LnKiArNzTJQ=


### PR DESCRIPTION
### What

Updated default healthcheck config values:
- HealthCheckInterval:        30 * time.Second (env `HEALTHCHECK_INTERVAL`)
- HealthCheckCriticalTimeout: 90 * time.Second (env `HEALTHCHECK_CRITICAL_TIMEOUT`)

### How to review

- Make sure the default config uses the expected values and env vars

### Who can review

Anyone.