### PR TITLE
Graceful shutdown improvements

### DIFF
--- a/cmd/dp-hierarchy-api/main.go
+++ b/cmd/dp-hierarchy-api/main.go
@@ -86,24 +86,32 @@ func main() {
 
 	// gracefully shutdown the application, closing any open resources
 	logData["timeout"] = config.ShutdownTimeout
-	log.Event(ctx, "start shutdown", log.ERROR, log.Error(err), logData)
+	log.Event(ctx, "start shutdown", log.INFO, logData)
 	shutdownContext, shutdownContextCancel := context.WithTimeout(context.Background(), config.ShutdownTimeout)
-
-	hc.Stop()
+	hasShutdownError := false
 
 	go func() {
+
+		log.Event(ctx, "stopping health checks", log.INFO)
+		hc.Stop()
+		log.Event(ctx, "health checks stopped", log.INFO)
+
 		if wantHTTPShutdown {
+			log.Event(ctx, "stopping http server", log.INFO)
 			if err := srv.Shutdown(shutdownContext); err != nil {
 				log.Event(ctx, "error closing http server", log.ERROR, log.Error(err))
+				hasShutdownError = true
 			} else {
 				log.Event(ctx, "http server shutdown", log.INFO)
 			}
 		}
 
+		log.Event(ctx, "closing graph db connection", log.INFO)
 		if err := graphDB.Close(shutdownContext); err != nil {
 			log.Event(ctx, "error closing db connection", log.ERROR, log.Error(err))
+			hasShutdownError = true
 		} else {
-			log.Event(ctx, "db connection shutdown", log.INFO)
+			log.Event(ctx, "graph db connection closed", log.INFO)
 		}
 
 		shutdownContextCancel()
@@ -112,8 +120,14 @@ func main() {
 	// wait for timeout or success (cancel)
 	<-shutdownContext.Done()
 
-	log.Event(ctx, "Shutdown done", log.INFO, log.Data{"context": shutdownContext.Err()})
-	os.Exit(1)
+	if hasShutdownError {
+		err = errors.New("failed to shutdown gracefully")
+		log.Event(ctx, "failed to shutdown gracefully ", log.ERROR, log.Error(err))
+		os.Exit(1)
+	}
+
+	log.Event(ctx, "graceful shutdown was successful", log.INFO)
+	os.Exit(0)
 }
 
 func startHealthCheck(ctx context.Context, config *config.Config, graphDB *graph.DB) *healthcheck.HealthCheck {

--- a/cmd/dp-hierarchy-api/main.go
+++ b/cmd/dp-hierarchy-api/main.go
@@ -94,15 +94,12 @@ func main() {
 
 		log.Event(ctx, "stopping health checks", log.INFO)
 		hc.Stop()
-		log.Event(ctx, "health checks stopped", log.INFO)
 
 		if wantHTTPShutdown {
 			log.Event(ctx, "stopping http server", log.INFO)
 			if err := srv.Shutdown(shutdownContext); err != nil {
 				log.Event(ctx, "error closing http server", log.ERROR, log.Error(err))
 				hasShutdownError = true
-			} else {
-				log.Event(ctx, "http server shutdown", log.INFO)
 			}
 		}
 
@@ -110,8 +107,6 @@ func main() {
 		if err := graphDB.Close(shutdownContext); err != nil {
 			log.Event(ctx, "error closing db connection", log.ERROR, log.Error(err))
 			hasShutdownError = true
-		} else {
-			log.Event(ctx, "graph db connection closed", log.INFO)
 		}
 
 		shutdownContextCancel()


### PR DESCRIPTION
### What
Graceful shutdown improvements
- move call to hc.Stop() inside the go routine that handles the graceful shutdown. Having it outside prevents the shutdown context timeout from taking effect if the call to hc.Stop() hangs
- change the `start shutdown` log to log as INFO instead of ERROR
- add more logging around the graceful shutdown
- track errors during shutdown and pass in a zero value to os.Exit() if no error occurs during shutdown

### How to review
Review / test changes

### Who can review
Anyone
