### PR TITLE
Release/1.14.0

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,10 +3,11 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	dbmodels "github.com/ONSdigital/dp-graph/v2/models"
 	"github.com/ONSdigital/dp-hierarchy-api/datastore"
-	"net/http"
 
 	"github.com/ONSdigital/dp-hierarchy-api/models"
 	"github.com/ONSdigital/log.go/log"
@@ -142,6 +143,7 @@ func mapHierarchyResponse(dbResponse *dbmodels.HierarchyResponse) models.Respons
 		NoOfChildren: dbResponse.NoOfChildren,
 		HasData:      dbResponse.HasData,
 		Breadcrumbs:  mapHierarchyElements(dbResponse.Breadcrumbs),
+		Order:        dbResponse.Order,
 	}
 
 	return response
@@ -158,6 +160,7 @@ func mapHierarchyElements(dbElements []*dbmodels.HierarchyElement) []*models.Ele
 			Label:        dbElement.Label,
 			NoOfChildren: dbElement.NoOfChildren,
 			HasData:      dbElement.HasData,
+			Order:        dbElement.Order,
 		}
 
 		elements = append(elements, element)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -103,28 +103,30 @@ func TestMapHierarchyResponse(t *testing.T) {
 	})
 
 	Convey("A populated DB response without children or breadcrumbs is mapped to the corresponding API response", t, func() {
+		var order int64 = 123
 		dbResponse := &dbmodels.HierarchyResponse{
 			ID:      "testID",
 			Label:   "testLabel",
-			Order:   123,
+			Order:   &order,
 			HasData: true,
 		}
 		expected := models.Response{
 			ID:      "testID",
 			Label:   "testLabel",
-			Order:   123,
+			Order:   &order,
 			HasData: true,
 		}
 		So(mapHierarchyResponse(dbResponse), ShouldResemble, expected)
 	})
 
 	Convey("A DB response with children is mapped to the corresponding API response", t, func() {
+		var order int64 = 321
 		dbResponse := &dbmodels.HierarchyResponse{
 			Children: []*dbmodels.HierarchyElement{
 				{
 					ID:      "childID",
 					Label:   "childLabel",
-					Order:   321,
+					Order:   &order,
 					HasData: true,
 				},
 			},
@@ -135,7 +137,7 @@ func TestMapHierarchyResponse(t *testing.T) {
 				{
 					ID:      "childID",
 					Label:   "childLabel",
-					Order:   321,
+					Order:   &order,
 					HasData: true,
 				},
 			},
@@ -145,12 +147,13 @@ func TestMapHierarchyResponse(t *testing.T) {
 	})
 
 	Convey("A DB response with breadcrumbs is mapped to the corresponding API response", t, func() {
+		var order int64 = 456
 		dbResponse := &dbmodels.HierarchyResponse{
 			Breadcrumbs: []*dbmodels.HierarchyElement{
 				{
 					ID:      "bcID",
 					Label:   "bcLabel",
-					Order:   456,
+					Order:   &order,
 					HasData: true,
 				},
 			},
@@ -160,7 +163,7 @@ func TestMapHierarchyResponse(t *testing.T) {
 				{
 					ID:      "bcID",
 					Label:   "bcLabel",
-					Order:   456,
+					Order:   &order,
 					HasData: true,
 				},
 			},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -2,12 +2,14 @@ package api
 
 import (
 	"context"
-	"github.com/ONSdigital/dp-graph/v2/graph/driver"
-	dbmodels "github.com/ONSdigital/dp-graph/v2/models"
-	"github.com/ONSdigital/dp-hierarchy-api/datastore/datastoretest"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/ONSdigital/dp-graph/v2/graph/driver"
+	dbmodels "github.com/ONSdigital/dp-graph/v2/models"
+	"github.com/ONSdigital/dp-hierarchy-api/datastore/datastoretest"
+	"github.com/ONSdigital/dp-hierarchy-api/models"
 
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
@@ -88,5 +90,81 @@ func TestAPIResponseStatuses(t *testing.T) {
 
 		api.codesHandler(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
+	})
+}
+
+func TestMapHierarchyResponse(t *testing.T) {
+	t.Parallel()
+
+	Convey("An empty DB response is mapped to an empty API response", t, func() {
+		dbResponse := &dbmodels.HierarchyResponse{}
+		expected := models.Response{}
+		So(mapHierarchyResponse(dbResponse), ShouldResemble, expected)
+	})
+
+	Convey("A populated DB response without children or breadcrumbs is mapped to the corresponding API response", t, func() {
+		dbResponse := &dbmodels.HierarchyResponse{
+			ID:      "testID",
+			Label:   "testLabel",
+			Order:   123,
+			HasData: true,
+		}
+		expected := models.Response{
+			ID:      "testID",
+			Label:   "testLabel",
+			Order:   123,
+			HasData: true,
+		}
+		So(mapHierarchyResponse(dbResponse), ShouldResemble, expected)
+	})
+
+	Convey("A DB response with children is mapped to the corresponding API response", t, func() {
+		dbResponse := &dbmodels.HierarchyResponse{
+			Children: []*dbmodels.HierarchyElement{
+				{
+					ID:      "childID",
+					Label:   "childLabel",
+					Order:   321,
+					HasData: true,
+				},
+			},
+			NoOfChildren: 1,
+		}
+		expected := models.Response{
+			Children: []*models.Element{
+				{
+					ID:      "childID",
+					Label:   "childLabel",
+					Order:   321,
+					HasData: true,
+				},
+			},
+			NoOfChildren: 1,
+		}
+		So(mapHierarchyResponse(dbResponse), ShouldResemble, expected)
+	})
+
+	Convey("A DB response with breadcrumbs is mapped to the corresponding API response", t, func() {
+		dbResponse := &dbmodels.HierarchyResponse{
+			Breadcrumbs: []*dbmodels.HierarchyElement{
+				{
+					ID:      "bcID",
+					Label:   "bcLabel",
+					Order:   456,
+					HasData: true,
+				},
+			},
+		}
+		expected := models.Response{
+			Breadcrumbs: []*models.Element{
+				{
+					ID:      "bcID",
+					Label:   "bcLabel",
+					Order:   456,
+					HasData: true,
+				},
+			},
+		}
+		So(mapHierarchyResponse(dbResponse), ShouldResemble, expected)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.33.6
-	github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426105842-ca9fa1f9a2a2
+	github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426142334-973f414140eb
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.11
 	github.com/ONSdigital/log.go v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.33.6
-	github.com/ONSdigital/dp-graph/v2 v2.11.0
+	github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426105842-ca9fa1f9a2a2
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.11
 	github.com/ONSdigital/log.go v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.33.6
-	github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426142334-973f414140eb
+	github.com/ONSdigital/dp-graph/v2 v2.12.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.11
 	github.com/ONSdigital/log.go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.33.6 h1:RsVZ7a5Z8tpUpe6ARA2+XmdbG8BAYCJXBWkX6fDBnyE=
 github.com/ONSdigital/dp-api-clients-go v1.33.6/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
-github.com/ONSdigital/dp-graph/v2 v2.11.0 h1:I2qEXSPFTvidQ31nm0Uy0PNqLAqXyviVkP1sys3evSE=
-github.com/ONSdigital/dp-graph/v2 v2.11.0/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
+github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426105842-ca9fa1f9a2a2 h1:8gDwQwHoAFjactSTpYWGfHcL0JrCxpkeU4tJ29c6fw0=
+github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426105842-ca9fa1f9a2a2/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.33.6 h1:RsVZ7a5Z8tpUpe6ARA2+XmdbG8BAYCJXBWkX6fDBnyE=
 github.com/ONSdigital/dp-api-clients-go v1.33.6/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
-github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426142334-973f414140eb h1:h2t+/L8sjM9iVTfywcnQ/Ug4QSHPQaOs6G0YIUBFUyI=
-github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426142334-973f414140eb/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
+github.com/ONSdigital/dp-graph/v2 v2.12.0 h1:QBHPgLIgCEOZ/EsGMCDvxLc3YehE0WsEsubdMYzzWJg=
+github.com/ONSdigital/dp-graph/v2 v2.12.0/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.33.6 h1:RsVZ7a5Z8tpUpe6ARA2+XmdbG8BAYCJXBWkX6fDBnyE=
 github.com/ONSdigital/dp-api-clients-go v1.33.6/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
-github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426105842-ca9fa1f9a2a2 h1:8gDwQwHoAFjactSTpYWGfHcL0JrCxpkeU4tJ29c6fw0=
-github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426105842-ca9fa1f9a2a2/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
+github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426142334-973f414140eb h1:h2t+/L8sjM9iVTfywcnQ/Ug4QSHPQaOs6G0YIUBFUyI=
+github.com/ONSdigital/dp-graph/v2 v2.11.3-0.20210426142334-973f414140eb/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=

--- a/models/response.go
+++ b/models/response.go
@@ -16,7 +16,7 @@ type Response struct {
 	Label        string          `json:"label"`
 	Children     []*Element      `json:"children,omitempty"`
 	NoOfChildren int64           `json:"no_of_children,omitempty"`
-	Order        int64           `json:"order,omitempty"`
+	Order        *int64          `json:"order,omitempty"`
 	Links        map[string]Link `json:"links,omitempty"`
 	HasData      bool            `json:"has_data"`
 	Breadcrumbs  []*Element      `json:"breadcrumbs,omitempty"`
@@ -27,7 +27,7 @@ type Element struct {
 	ID           string          `json:"-"`
 	Label        string          `json:"label"`
 	NoOfChildren int64           `json:"no_of_children,omitempty"`
-	Order        int64           `json:"order,omitempty"`
+	Order        *int64          `json:"order,omitempty"`
 	Links        map[string]Link `json:"links,omitempty"`
 	HasData      bool            `json:"has_data"`
 }

--- a/models/response.go
+++ b/models/response.go
@@ -16,6 +16,7 @@ type Response struct {
 	Label        string          `json:"label"`
 	Children     []*Element      `json:"children,omitempty"`
 	NoOfChildren int64           `json:"no_of_children,omitempty"`
+	Order        int64           `json:"order,omitempty"`
 	Links        map[string]Link `json:"links,omitempty"`
 	HasData      bool            `json:"has_data"`
 	Breadcrumbs  []*Element      `json:"breadcrumbs,omitempty"`
@@ -26,6 +27,7 @@ type Element struct {
 	ID           string          `json:"-"`
 	Label        string          `json:"label"`
 	NoOfChildren int64           `json:"no_of_children,omitempty"`
+	Order        int64           `json:"order,omitempty"`
 	Links        map[string]Link `json:"links,omitempty"`
 	HasData      bool            `json:"has_data"`
 }


### PR DESCRIPTION
### What

Release branch for order field returned when getting a hierarchy. This is needed by the flatten geography logic in `dp-frontend-filter-dataset-controller`.

Trello card: https://trello.com/c/SmZAgSkp/5048-display-hierarchies-in-filter-journey-in-a-consistent-order

### How to review

Make sure that only the expected commits (return order field) are present in the branch.

### Who can review

Anyone