### PR TITLE
Feature/url rewriting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ test:
 
 PHONY: lint
 lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 	golangci-lint run ./...
 
 test-component:

--- a/api/api.go
+++ b/api/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	dbmodels "github.com/ONSdigital/dp-graph/v2/models"
 	"github.com/ONSdigital/dp-hierarchy-api/datastore"
+	"github.com/ONSdigital/dp-net/v2/links"
 
 	"github.com/ONSdigital/dp-hierarchy-api/models"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -68,7 +69,14 @@ func (api *API) hierarchiesHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	res := mapHierarchyResponse(dbRes)
-	res.AddLinks(api.host.String(), instance, dimension, codelistID, true)
+
+	if api.enableURLRewriting {
+		hierarchyLinksBuilder := links.FromHeadersOrDefault(&req.Header, req, api.host)
+		codeListLinksBuilder := links.FromHeadersOrDefault(&req.Header, req, api.codeListAPIURL)
+		res.AddLinksWithRewriting(hierarchyLinksBuilder.URL.String(), codeListLinksBuilder.URL.String(), instance, dimension, codelistID, true)
+	} else {
+		res.AddLinks(api.host.String(), instance, dimension, codelistID, true)
+	}
 
 	b, err := json.Marshal(res)
 	if err != nil {
@@ -124,7 +132,14 @@ func (api *API) codesHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	res := mapHierarchyResponse(dbRes)
-	res.AddLinks(api.host.String(), instance, dimension, codelistID, false)
+
+	if api.enableURLRewriting {
+		hierarchyLinksBuilder := links.FromHeadersOrDefault(&req.Header, req, api.host)
+		codeListLinksBuilder := links.FromHeadersOrDefault(&req.Header, req, api.codeListAPIURL)
+		res.AddLinksWithRewriting(hierarchyLinksBuilder.URL.String(), codeListLinksBuilder.URL.String(), instance, dimension, codelistID, false)
+	} else {
+		res.AddLinks(api.host.String(), instance, dimension, codelistID, false)
+	}
 
 	b, err := json.Marshal(res)
 	if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
@@ -15,11 +16,11 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const (
-	hierarchyAPIURL = "http://fake-hier"
+var (
+	router          = mux.NewRouter()
+	codeListAPIURL  = &url.URL{Scheme: "http", Host: "localhost:22400"}
+	hierarchyAPIURL = &url.URL{Scheme: "http", Host: "localhost:22600"}
 )
-
-var router = mux.NewRouter()
 
 func TestAPIResponseStatuses(t *testing.T) {
 	t.Parallel()
@@ -56,7 +57,7 @@ func TestAPIResponseStatuses(t *testing.T) {
 		r := httptest.NewRequest("GET", "/hierarchies/hier12/dim34", nil)
 		w := httptest.NewRecorder()
 
-		api := New(router, validMockDatastore, hierarchyAPIURL)
+		api := New(router, validMockDatastore, hierarchyAPIURL, codeListAPIURL, false)
 
 		api.hierarchiesHandler(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -66,7 +67,7 @@ func TestAPIResponseStatuses(t *testing.T) {
 		r := httptest.NewRequest("GET", "/hierarchies/hier12/dim34/codeN", nil)
 		w := httptest.NewRecorder()
 
-		api := New(router, validMockDatastore, hierarchyAPIURL)
+		api := New(router, validMockDatastore, hierarchyAPIURL, codeListAPIURL, false)
 
 		api.codesHandler(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -76,7 +77,7 @@ func TestAPIResponseStatuses(t *testing.T) {
 		r := httptest.NewRequest("GET", "/hierarchies/none/dim34", nil)
 		w := httptest.NewRecorder()
 
-		api := New(router, notFoundMockDatastore, hierarchyAPIURL)
+		api := New(router, notFoundMockDatastore, hierarchyAPIURL, codeListAPIURL, false)
 
 		api.hierarchiesHandler(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
@@ -86,7 +87,7 @@ func TestAPIResponseStatuses(t *testing.T) {
 		r := httptest.NewRequest("GET", "/hierarchies/none/dim34/codeN", nil)
 		w := httptest.NewRecorder()
 
-		api := New(router, notFoundMockDatastore, hierarchyAPIURL)
+		api := New(router, notFoundMockDatastore, hierarchyAPIURL, codeListAPIURL, false)
 
 		api.codesHandler(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)

--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -3,5 +3,6 @@
 cwd=$(pwd)
 
 pushd $cwd/dp-hierarchy-api
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
   make lint
 popd

--- a/cmd/dp-hierarchy-api/main.go
+++ b/cmd/dp-hierarchy-api/main.go
@@ -82,7 +82,7 @@ func main() {
 	srv.HandleOSSignals = false
 
 	// put constants into model
-	models.CodelistURL = config.CodelistAPIURL
+	models.CodelistURL = codeListAPIURL.String()
 
 	// start http server
 	httpServerDoneChan := make(chan error)

--- a/cmd/dp-hierarchy-api/main.go
+++ b/cmd/dp-hierarchy-api/main.go
@@ -35,6 +35,7 @@ func main() {
 	config, err := config.Get()
 	if err != nil {
 		log.Fatal(ctx, "error getting config", err)
+		os.Exit(1)
 	}
 
 	signals := make(chan os.Signal, 1)
@@ -44,6 +45,7 @@ func main() {
 	graphDB, err := graph.NewHierarchyStore(ctx)
 	if err != nil {
 		log.Fatal(ctx, "error creating hierarchy store", err)
+		os.Exit(1)
 	}
 
 	graphErrorConsumer := graph.NewLoggingErrorConsumer(ctx, graphDB.Errors)
@@ -154,6 +156,7 @@ func startHealthCheck(ctx context.Context, config *config.Config, graphDB *graph
 	versionInfo, err := healthcheck.NewVersionInfo(BuildTime, GitCommit, Version)
 	if err != nil {
 		log.Fatal(ctx, "error creating version info", err)
+		hasErrors = true
 	}
 
 	hc := healthcheck.New(versionInfo, config.HealthCheckCriticalTimeout, config.HealthCheckInterval)

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	CodelistAPIURL             string        `envconfig:"CODE_LIST_URL"`
+	EnableURLRewriting         bool          `envconfig:"ENABLE_URL_REWRITING"`
 }
 
 var configuration *Config
@@ -28,6 +29,7 @@ func Get() (*Config, error) {
 			HealthCheckInterval:        30 * time.Second,
 			HealthCheckCriticalTimeout: 90 * time.Second,
 			CodelistAPIURL:             "http://localhost:22400",
+			EnableURLRewriting:         false,
 		}
 		if err := envconfig.Process("", configuration); err != nil {
 			return nil, err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,7 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			ShutdownTimeout:            5 * time.Second,
 			HealthCheckInterval:        30 * time.Second,
 			HealthCheckCriticalTimeout: 90 * time.Second,
+			EnableURLRewriting:         false,
 		})
 	})
 }


### PR DESCRIPTION
### What

Added `EnableURLRewriting` feature flag
Both GET endpoints rewrite links based on ticket requirements
https://jira.ons.gov.uk/browse/DIS-1615

### How to review

CMD stack must be running
make a request to `http://localhost:22600/hierarchies/af89f0a0-760c-48c6-8af5-79616b3f9a1b/aggregate`
codelistAPI links should be built with the codelistAPI host config value
HierarchyAPI links should be built with the HierarchyAPI host config value
Set `X-Forwarded-Proto` to `https`
Set `X-Forwarded-Host` to `api.example.com`
Make the same request again and all links should be built using the X-Forwarded values
Making the same request again with the forwarded values but to the api-router should create links with `/v1` in them

### Who can review

Anyone
